### PR TITLE
Handle travel advisory entries without summaries

### DIFF
--- a/traveladvisories.py
+++ b/traveladvisories.py
@@ -89,7 +89,7 @@ def main(
             "id": guid,
             "url": entry["link"],
             "title": title,
-            "content_html": entry["summary"],
+            "content_html": _entry_content_html(entry),
             "date_published": published_datetime.isoformat(),
         }
         items[slug] = item
@@ -120,6 +120,21 @@ def main(
         feed = _feed(country="Combined", slug="combined", items=combine_items)
         output_path = output_dir / "combined.json"
         json.dump(feed, output_path.open("w"), indent=4)
+
+
+def _entry_content_html(entry: feedparser.FeedParserDict) -> str:
+    if summary := entry.get("summary"):
+        return str(summary)
+
+    if description := entry.get("description"):
+        return str(description)
+
+    for content in entry.get("content", []):
+        if value := content.get("value"):
+            return str(value)
+
+    logger.warning("No summary found for '%s'", entry.get("link", entry.get("title")))
+    return ""
 
 
 def _get_html_title(url: str) -> str | None:


### PR DESCRIPTION
### Motivation
- Avoid `KeyError` when a parsed State Department RSS entry omits the `summary` field and the code indexes `entry["summary"]` directly. 
- Make content extraction more robust by falling back to other content-like fields present in RSS entries. 
- Ensure feeds are generated even when some feed items lack a `summary` value.

### Description
- Replace direct use of `entry["summary"]` with a helper function ` _entry_content_html(entry)` in `traveladvisories.py` when building `FeedItem` objects. 
- Implement ` _entry_content_html(entry)` to return `summary` if present, then `description`, then the first `content[].value`, and otherwise log a warning and return an empty string. 
- Keep existing feed generation and JSON output behavior unchanged aside from the safer content extraction.

### Testing
- Ran `uv run ruff format .` which left files unchanged and succeeded. 
- Ran `uv run ruff check .` which completed with all checks passed. 
- Ran `uv run mypy .` which reported success with no issues. 
- Executed `uv run traveladvisories --output-dir /tmp/traveladvisories-test` and the command completed (logs show fetch attempt). 
- Ran inline Python assertions covering ` _entry_content_html()` for `summary`, `description`, `content`, and missing-content cases which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5efe47e9388326a693c64f8ec67ed4)