### PR TITLE
Fix Ruff 0.16 timezone lint compatibility

### DIFF
--- a/traveladvisories.py
+++ b/traveladvisories.py
@@ -75,8 +75,9 @@ def main(
         if "See Individual Summaries" in title:
             title = _get_html_title(entry["link"])
 
-        published_datetime = datetime(*entry["published_parsed"][:6]).replace(
-            tzinfo=UTC
+        year, month, day, hour, minute, second = entry["published_parsed"][:6]
+        published_datetime = datetime(
+            year, month, day, hour, minute, second, tzinfo=UTC
         )
         published_timestamp: int = int(published_datetime.timestamp())
         guid = f"{slug}-{published_timestamp}"


### PR DESCRIPTION
### Motivation
- Ensure forward compatibility with `ruff` 0.16's `DTZ001` rule by constructing timezone-aware datetimes without creating a naive `datetime` and then replacing its timezone.

### Description
- Unpack `entry["published_parsed"]` into `year, month, day, hour, minute, second` and construct `datetime(year, month, day, hour, minute, second, tzinfo=UTC)` in `traveladvisories.py` to satisfy the linter and strict `mypy` checks.

### Testing
- Ran `ruff format .`, `ruff check .`, `ruff check --preview .`, `ruff format --preview --check .`, `uv run mypy .`, and `python -m compileall -q traveladvisories.py`, all of which passed; an attempt to run `uvx --from ruff==0.16.0 ...` failed because `ruff==0.16.0` could not be downloaded from PyPI in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e6618e9fc832694ca0775a65541f2)