### PR TITLE
Send User-Agent when fetching travel advisories

### DIFF
--- a/traveladvisories.py
+++ b/traveladvisories.py
@@ -19,6 +19,7 @@ _FEED_HOMEPAGE_URL = (
 _FEED_ICON_URL = (
     "https://travel.state.gov/content/dam/tsg-global/tsg_link_img_display.jpg"
 )
+_USER_AGENT = "us-state-travel-advisories-feeds/0.1 (+https://github.com/josh/us-state-travel-advisories-feeds)"
 
 
 class FeedItem(TypedDict):
@@ -57,7 +58,9 @@ def main(
 
     url = "https://travel.state.gov/_res/rss/TAsTWs.xml"
     logger.info("Fetch %s", url)
-    d: feedparser.FeedParserDict = feedparser.parse(url)
+    d: feedparser.FeedParserDict = feedparser.parse(
+        url, request_headers={"User-Agent": _USER_AGENT}
+    )
 
     items: dict[str, FeedItem] = {}
     legacy_slugs = {
@@ -145,7 +148,8 @@ def _slugify(country: str) -> str:
 
 
 def _get_html_title(url: str) -> str | None:
-    with urllib.request.urlopen(url) as response:
+    request = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(request) as response:
         html = response.read().decode("utf-8")
         if m := re.search(r"<title>(.*?)</title>", html):
             return m[1].strip()


### PR DESCRIPTION
### Motivation
- The scheduled publish job was failing because the State Department site was rejecting automated HTTP requests, so requests should identify the client with a `User-Agent` header.

### Description
- Add a `_USER_AGENT` constant with an identifying agent string.
- Pass the header to `feedparser.parse` via `request_headers={"User-Agent": _USER_AGENT}` when fetching the RSS feed.
- Use `urllib.request.Request(..., headers={"User-Agent": _USER_AGENT})` for advisory detail-page requests in `_get_html_title`.
- Changes updated `traveladvisories.py` and committed with the message "Send user agent when fetching travel advisories".

### Testing
- Ran `uv run ruff format .` and `uv run ruff check .`, both succeeded.
- Ran `uv run mypy .`, which succeeded.
- Ran `git diff --check`, which reported no issues.
- Ran `uv run traveladvisories --output-dir /tmp/advisories-test --verbose`, which executed but the environment proxy blocked external HTTP requests to `travel.state.gov` with HTTP 403 so the live feed fetch could not be fully validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7946e7aa5c832685c61a377e94a3fc)